### PR TITLE
change structure readme template

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1,5 +1,3 @@
-<!-- Parts of this template are inspired by https://github.com/othneildrew/Best-README-Template -->
-
 # Project Title
 
 <!-- Include Github badges here (optional) -->
@@ -13,59 +11,16 @@ Description of this (technical) project and of the project itself.
 
 - [Project Title](#project-title)
   - [Table of Contents](#table-of-contents)
-  - [About the Project](#about-the-project)
-    - [Built with](#built-with)
-    - [License](#license)
-    - [Attribution and academic use](#attribution-and-academic-use)
   - [Getting Started](#getting-started)
     - [Prerequisites](#prerequisites)
     - [Installation](#installation)
   - [Usage](#usage)
     - [Subsection](#subsection)
-  - [Links](#links)
+  - [About the Project](#about-the-project)
+    - [License](#license)
+    - [Attribution and academic use](#attribution-and-academic-use)
   - [Contributing](#contributing)
-  - [Notes](#notes)
   - [Contact](#contact)
-
-<!-- ABOUT THE PROJECT -->
-## About the Project
-
-**Date**: Month Year
-
-**Researcher(s)**:
-
-- Name of researcher 1 (researcher.1@uu.nl)
-- Name of researcher 2 (researcher.2@uu.nl)
-
-**Research Software Engineer(s)**:
-
-- Name of RSE 1 (rse.1@uu.nl)
-- Name of RSE 2 (rse.2@uu.nl)
-
-### Built with
-
-This section should list any major frameworks used to build this project.
-
-- [Framework 1](exampleframework.com)
-- [Framework 2](exampleframework.com)
-
-<!-- Do not forget to also include the license in a separate file(LICENSE[.txt/.md]) and link it properly. -->
-### License
-
-The code in this project is released under [License name](LICENSE).
-
-### Attribution and academic use
-
-What to include here depends on the project type.
-
-If a paper has been published introducing this code, include a reference to that paper:
-[Example](https://github.com/OceanParcels/parcels#parcels-manuscript-and-code)
-
-If the software has been published on its own, include a reference to that:
-[Example](https://github.com/asreview/asreview#citation)
-
-If a dataset has been published from this repository, include a persistent link to the dataset:
-[Example](https://github.com/J535D165/CoronaWatchNL#license-and-academic-use)
 
 <!-- GETTING STARTED -->
 ## Getting Started
@@ -102,13 +57,39 @@ python -m example.py
 
 _For more examples, please refer to the [Documentation](sphinx-doc-website)_
 
-<!-- LINKS -->
-## Links
+<!-- ABOUT THE PROJECT -->
+## About the Project
 
-An overview of interesting links related to the project.
+**Date**: Month Year
 
-- [Install R and Rstudio on MAC](https://medium.com/@GalarnykMichael/install-r-and-rstudio-on-mac-e911606ce4f4)
-- [Install Anaconda Python](https://www.anaconda.com/download/)
+**Researcher(s)**:
+
+- Name of researcher 1 (researcher.1@uu.nl)
+- Name of researcher 2 (researcher.2@uu.nl)
+
+**Research Software Engineer(s)**:
+
+- Name of RSE 1 (rse.1@uu.nl)
+- Name of RSE 2 (rse.2@uu.nl)
+
+
+<!-- Do not forget to also include the license in a separate file(LICENSE[.txt/.md]) and link it properly. -->
+### License
+
+The code in this project is released under [License name](LICENSE).
+
+### Attribution and academic use
+
+What to include here depends on the project type.
+
+If a paper has been published introducing this code, include a reference to that paper:
+[Example](https://github.com/OceanParcels/parcels#parcels-manuscript-and-code)
+
+If the software has been published on its own, include a reference to that:
+[Example](https://github.com/asreview/asreview#citation)
+
+If a dataset has been published from this repository, include a persistent link to the dataset:
+[Example](https://github.com/J535D165/CoronaWatchNL#license-and-academic-use)
 
 <!-- CONTRIBUTING -->
 ## Contributing
@@ -122,11 +103,6 @@ To contribute:
 3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
 4. Push to the Branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
-
-<!-- NOTES -->
-## Notes
-
-Additional notes on the project can be left here.
 
 <!-- CONTACT -->
 ## Contact

--- a/README-template.md
+++ b/README-template.md
@@ -4,7 +4,7 @@
 <!-- e.g. Github Actions workflow status -->
 ![workflow name](https://github.com/UtrechtUniversity/<REPOSITORY>/workflows/<WORKFLOW_NAME_OR_FILE_PATH>/badge.svg)
 
-Description of this (technical) project and of the project itself.
+Include a short description of the repository/project here (few sentences)
 
 <!-- TABLE OF CONTENTS -->
 ## Table of Contents
@@ -17,6 +17,7 @@ Description of this (technical) project and of the project itself.
   - [Usage](#usage)
     - [Subsection](#subsection)
   - [About the Project](#about-the-project)
+    - [Description](#description)  
     - [License](#license)
     - [Attribution and academic use](#attribution-and-academic-use)
   - [Contributing](#contributing)
@@ -72,6 +73,8 @@ _For more examples, please refer to the [Documentation](sphinx-doc-website)_
 - Name of RSE 1 (rse.1@uu.nl)
 - Name of RSE 2 (rse.2@uu.nl)
 
+<!-- A more elaborate description about the project/software (compared to the top of this page) can be included here-->
+### Description
 
 <!-- Do not forget to also include the license in a separate file(LICENSE[.txt/.md]) and link it properly. -->
 ### License


### PR DESCRIPTION
We thought that for the reader it now takes too much scrolling down to find the getting started instructions. Proposal is to move the 'about the project' section down, so after the project description the reader finds instructions to get started straight away. I also suggest to remove the sections 'links' and 'notes', as they don't add much and can be included in a later stage if there is really some info to put there. 